### PR TITLE
Make release() fns take &self instead of self as arg

### DIFF
--- a/fmod-oxide/src/core/dsp/general.rs
+++ b/fmod-oxide/src/core/dsp/general.rs
@@ -50,7 +50,7 @@ impl Dsp {
     ///
     /// If [`Dsp`] is not removed from the network with `ChannelControl::removeDSP` after being added with `ChannelControl::addDSP`,
     /// it will not release and will instead return [`FMOD_RESULT::FMOD_ERR_DSP_INUSE`].
-    pub fn release(self) -> Result<()> {
+    pub fn release(&self) -> Result<()> {
         unsafe { FMOD_DSP_Release(self.inner.as_ptr()).to_result() }
     }
 

--- a/fmod-oxide/src/studio/command_replay/general.rs
+++ b/fmod-oxide/src/studio/command_replay/general.rs
@@ -10,7 +10,7 @@ use crate::studio::CommandReplay;
 
 impl CommandReplay {
     /// Releases the command replay.
-    pub fn release(self) -> Result<()> {
+    pub fn release(&self) -> Result<()> {
         unsafe { FMOD_Studio_CommandReplay_Release(self.inner.as_ptr()).to_result() }
     }
 }

--- a/fmod-oxide/src/studio/event_instance/general.rs
+++ b/fmod-oxide/src/studio/event_instance/general.rs
@@ -33,7 +33,7 @@ impl EventInstance {
     /// Generally it is a best practice to release event instances immediately after calling [`EventInstance::start`],
     /// unless you want to play the event instance multiple times or explicitly stop it and start it again later.
     /// It is possible to interact with the instance after falling [`EventInstance::release`], however if the sound has stopped [`FMOD_RESULT::FMOD_ERR_INVALID_HANDLE`] will be returned.
-    pub fn release(self) -> Result<()> {
+    pub fn release(&self) -> Result<()> {
         // we don't actually release userdata here because there is a callback, and the user might interact with the instance while it's being released
         unsafe { FMOD_Studio_EventInstance_Release(self.inner.as_ptr()).to_result() }
     }

--- a/fmod-oxide/src/studio/system/lifecycle.rs
+++ b/fmod-oxide/src/studio/system/lifecycle.rs
@@ -31,7 +31,7 @@ impl System {
     /// The FMOD Studio API attempts to protect against stale handles and pointers being used with a different Studio System object but this protection cannot be guaranteed and attempting to use stale handles or pointers may cause undefined behavior.
     ///
     /// This function is not safe to be called at the same time across multiple threads.
-    pub unsafe fn release(self) -> Result<()> {
+    pub unsafe fn release(&self) -> Result<()> {
         unsafe { FMOD_Studio_System_Release(self.inner.as_ptr()).to_result() }
     }
 


### PR DESCRIPTION
Since the various types that can be released are Copy (i.e. we're treating them as basically being pointers), it doesn't really make sense to have release() take ownership of self.

The alternative approach would be to remove the Copy impl from basically all the FMOD types so that we treat them as resources rather than pointers - and then maybe impl Drop for them? (at least for all except system).

Either way, good to pick an approach and stick to it.

---

The other fmod types are already taking `&self` so I just went with this approach since it's the most minimal approach, but from a "what I would expect from a Rust impl" perspective it'd be better to go with removing the Copy impls. Was there was a reason you chose to go with Copy + no Drop impls for the various FMOD types? I noticed there's a TODO for System pondering whether the Copy impl is correct.